### PR TITLE
Headless Bundle for Homepage

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -2,6 +2,7 @@ baseURL = "www.example.com"
 languageCode = "en-us"
 title = "Hugo Hero"
 theme = "hugo-hero-theme"
+themesDir = "../.."
 
 [params]
     google_analytics_id=""

--- a/exampleSite/content/homepage/about.md
+++ b/exampleSite/content/homepage/about.md
@@ -1,0 +1,7 @@
+---
+title: 'Our Difference'
+button: 'About us'
+weight: 2
+---
+
+Lorem ipsum dolor sit amet, et essent mediocritatem quo, choro volumus oporteat an mei. ipsum dolor sit amet, et essent mediocritatem quo,

--- a/exampleSite/content/homepage/index.md
+++ b/exampleSite/content/homepage/index.md
@@ -1,5 +1,3 @@
 ---
-title: 'We Help Business Grow'
-date: 2018-02-10T11:52:18+07:00
 headless : true
 ---

--- a/exampleSite/content/homepage/index.md
+++ b/exampleSite/content/homepage/index.md
@@ -1,0 +1,5 @@
+---
+title: 'We Help Business Grow'
+date: 2018-02-10T11:52:18+07:00
+headless : true
+---

--- a/exampleSite/content/homepage/work.md
+++ b/exampleSite/content/homepage/work.md
@@ -1,0 +1,7 @@
+---
+title: 'We Help Business Grow'
+button: 'Our Work'
+weight: 1
+---
+
+Lorem ipsum dolor sit amet, et essent mediocritatem quo, choro volumus oporteat an mei. Numquam dolores mel eu, mea docendi omittantur et, mea ea duis erat. Elit melius cu ius. Per ex novum tantas putant, ei his nullam aliquam apeirian. Aeterno quaestio constituto sea an, no eum intellegat assueverit. 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -23,9 +23,14 @@
   <div class="container">
     <div class="row">
       <div class="col-12 col-md-6 offset-md-6">
-        <h2 class="text-primary text-capitalize">We Help Business Grow</h2>
-        <p>Lorem ipsum dolor sit amet, et essent mediocritatem quo, choro volumus oporteat an mei. Numquam dolores mel eu, mea docendi omittantur et, mea ea duis erat. Elit melius cu ius. Per ex novum tantas putant, ei his nullam aliquam apeirian. Aeterno quaestio constituto sea an, no eum intellegat assueverit. </p>
-        <a class="button" href="{{ .Site.BaseURL }}work">Our Work</a>
+        {{ $headless := .Site.GetPage "/homepage" }}
+        {{ $reusablePages := $headless.Resources.ByType "page" }}
+        {{ $reusablePages := sort $reusablePages ".Params.weight" }}
+        {{ range first 1 $reusablePages }}
+        <h2 class="text-primary text-capitalize">{{ .Title }}</h2>
+        <p>{{ .Content }}</p>
+        <a class="button" href="{{ .Site.BaseURL }}work">{{ .Params.button }}</a>
+        {{ end }}
       </div>
     </div>
   </div>
@@ -54,9 +59,11 @@
   <div class="container pt-8 pb-8 pb-md-12 pt-md-12">
     <div class="row justify-content-center">
       <div class="col-12 col-md-8 text-center text-white">
-          <h2>Our Difference</h2>
-          <p>Lorem ipsum dolor sit amet, et essent mediocritatem quo, choro volumus oporteat an mei. ipsum dolor sit amet, et essent mediocritatem quo, </p>
-          <a class="button button-white" href="{{ .Site.BaseURL }}about">About Us</a>
+        {{ range first 1 (after 1 $reusablePages) }}
+          <h2>{{ .Title }}</h2>
+          <p>{{ .Content }}</p>
+          <a class="button button-white" href="{{ .Site.BaseURL }}about">{{ .Params.button }}</a>
+          {{ end }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR address offers a blueprint for resolving #1 

Summary:
I have configured a headless bundle called `homepage` so that users can customize the text snippets in the `About` and `Services` sections, that are currently hardcoded in the `index.html` template.

The logic demonstrated here can be applied to the other pages of this theme that also have hardcoded text directly in the templates.

In the theme's README there should also be some instructions to users about customizing the text snippets.

Also see the documentation about [Headless Bundles](https://gohugo.io/content-management/page-bundles/#headless-bundle)

cc: @digitalcraftsman